### PR TITLE
Fix for AutoLayout and tint color set globally

### DIFF
--- a/Classes/YHRoundBorderedButton.m
+++ b/Classes/YHRoundBorderedButton.m
@@ -62,10 +62,11 @@
     [self setNeedsDisplay];
 }
 
-- (void)setTintColor:(UIColor *)tintColor
+- (void)tintColorDidChange
 {
-    [super setTintColor:tintColor];
-    [self setTitleColor:tintColor forState:UIControlStateNormal];
+    [super tintColorDidChange];
+    
+    [self setTitleColor:self.tintColor forState:UIControlStateNormal];
     [self refreshBorderColor];
 }
 
@@ -101,6 +102,11 @@
 {
     CGSize org = [super sizeThatFits:self.bounds.size];
     return CGSizeMake(org.width + 20, org.height - 2);
+}
+
+- (CGSize)intrinsicContentSize
+{
+    return [self sizeThatFits:CGSizeMake(0,0)];
 }
 
 - (void)drawRect:(CGRect)rect


### PR DESCRIPTION
This PR adds a new method: intrinsicContentSize, which is called by AutoLayout to get the right size of the view.
Also setTintColor:tintColor was replaced by tintColorDidChange, so we wont set a tint color explicitly, but inherit the superviews or default tint color.

I have tested this multiple times in different projects and it works great with AutoLayout now and inherits a global set tint color.
